### PR TITLE
[TOOLS-2187] Update base image to deb11.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,10 @@
 # http://github.com/aerospike/aerospike-tools.docker
 #
 
-FROM debian:buster-slim 
+FROM debian:bullseye-slim 
 
 ENV AEROSPIKE_VERSION 7.2.1
-ENV AEROSPIKE_SHA256 138758441c164087cb5e136439f135064c70edd4083ba5e600f6d41512555306
+ENV AEROSPIKE_SHA256 b0f3f3414150295d9190c1894bd800cf0342e1d60b2acf85bdb7f2d769df9cb0
 
 # Work from /aerospike
 WORKDIR /aerospike
@@ -19,14 +19,15 @@ ENV PATH /aerospike:$PATH
 RUN \
   apt-get update -y \
   && apt-get install -y python3-pip python3 python3-distutils python3-apt python wget logrotate ca-certificates python3-dev python3-setuptools openssl python3-openssl libcurl4-openssl-dev\
-  && wget "https://www.aerospike.com/artifacts/aerospike-tools/${AEROSPIKE_VERSION}/aerospike-tools-${AEROSPIKE_VERSION}-debian10.tgz" -O aerospike-tools.tgz \
+  && wget "https://www.aerospike.com/artifacts/aerospike-tools/${AEROSPIKE_VERSION}/aerospike-tools-${AEROSPIKE_VERSION}-debian11.tgz" -O aerospike-tools.tgz \
   && echo "$AEROSPIKE_SHA256 *aerospike-tools.tgz" | sha256sum -c - \
+  && echo sha256sum aerospike-tools.tgz \ 
   && mkdir aerospike \
   && tar xzf aerospike-tools.tgz --strip-components=1 -C aerospike \
   && apt-get purge -y --auto-remove wget  
 
 
-RUN ls /aerospike/aerospike && dpkg -i /aerospike/aerospike/aerospike-tools-*.debian10.x86_64.deb \
+RUN ls /aerospike/aerospike && dpkg -i /aerospike/aerospike/aerospike-tools-*.debian11.x86_64.deb \
   && rm -rf aerospike-tools.tgz aerospike /var/lib/apt/lists/*
 
 # Addition of wrapper script

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,6 @@ RUN \
   && apt-get install -y python3-pip python3 python3-distutils python3-apt python wget logrotate ca-certificates python3-dev python3-setuptools openssl python3-openssl libcurl4-openssl-dev\
   && wget "https://www.aerospike.com/artifacts/aerospike-tools/${AEROSPIKE_VERSION}/aerospike-tools-${AEROSPIKE_VERSION}-debian11.tgz" -O aerospike-tools.tgz \
   && echo "$AEROSPIKE_SHA256 *aerospike-tools.tgz" | sha256sum -c - \
-  && echo sha256sum aerospike-tools.tgz \ 
   && mkdir aerospike \
   && tar xzf aerospike-tools.tgz --strip-components=1 -C aerospike \
   && apt-get purge -y --auto-remove wget  

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -20,7 +20,7 @@ if [ $? -ne 0 ]; then
 fi
 
 case "$CMD" in
-"aql" | "asadm" | "asbackup" | "asrestore" | "asloglatency" | "asinfo" | "asbench" ) 
+"aql" | "asadm" | "asbackup" | "asrestore" | "asloglatency" | "asinfo" | "asbench" | "uda" ) 
   ;;
 * )
   echo "error: Unknown command: $CMD" >&2


### PR DESCRIPTION
Also adds the "uda" command to wrapper.sh so that uda is reachable.

Testing: built and launched locally, tested --version on each tool.
```
MBP-D-Welch:aerospike-tools.docker dylanwelch$ docker run -it docker.io/aerospike/aerospike-tools aql --version
Aerospike Query Client
Version 7.0.4
C Client Version 6.0.0
Copyright 2012-2021 Aerospike. All rights reserved.
MBP-D-Welch:aerospike-tools.docker dylanwelch$ docker run -it docker.io/aerospike/aerospike-tools asbackup --version
Aerospike Backup Utility
Version 3.11.4
C Client Version 6.0.0
Copyright 2015-2021 Aerospike. All rights reserved.
MBP-D-Welch:aerospike-tools.docker dylanwelch$ docker run -it docker.io/aerospike/aerospike-tools asrestore --version
Aerospike Restore Utility
Version 3.11.4
C Client Version 6.0.0
Copyright 2015-2021 Aerospike. All rights reserved.
MBP-D-Welch:aerospike-tools.docker dylanwelch$ docker run -it docker.io/aerospike/aerospike-tools asinfo --version
Aerospike Information Tool
Version 2.9.1
MBP-D-Welch:aerospike-tools.docker dylanwelch$ docker run -it docker.io/aerospike/aerospike-tools asadm --version
Aerospike Administration Shell
Version 2.9.1
MBP-D-Welch:aerospike-tools.docker dylanwelch$ docker run -it docker.io/aerospike/aerospike-tools asbench --version
asbench version 1.4.0
MBP-D-Welch:aerospike-tools.docker dylanwelch$ docker run -it docker.io/aerospike/aerospike-tools uda --version
uda version 1.0.2
```