### PR TITLE
chore: TOOLS-2558 remove unused cl_py files

### DIFF
--- a/wrapper.sh
+++ b/wrapper.sh
@@ -2,8 +2,6 @@
 #set -x
 #set -e
 
-export PATH=$PATH:/opt/aerospike/lib/python
-export PYTHONPATH=$PYTHONPATH:/opt/aerospike/lib/python
 # Sets locale to utf-8 instead of posix. 
 # This allows asadm to display the mu symbol when micro-benchmarks are enabled
 export LC_CTYPE=C.UTF-8 


### PR DESCRIPTION
Update to reflect changes found in https://github.com/citrusleaf/aerospike-tools/pull/313