### PR TITLE
Revert "REL-2095 - Using ubuntu:22.04 as base image."

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 #
 # http://github.com/aerospike/aerospike-tools.docker
 #
-FROM ubuntu:22.04 as build
+FROM debian:bookworm-slim as build
 
 ARG TARGETARCH
 
@@ -13,7 +13,7 @@ RUN \
   wget
 
 ARG TOOLS_VERSION=10.2.1
-ARG TOOLS_ARTIFACT_URL_BASE="https://artifacts.aerospike.com/aerospike-tools/${TOOLS_VERSION}/aerospike-tools_${TOOLS_VERSION}_ubuntu22.04"
+ARG TOOLS_ARTIFACT_URL_BASE="https://artifacts.aerospike.com/aerospike-tools/${TOOLS_VERSION}/aerospike-tools_${TOOLS_VERSION}_debian12"
 
 RUN \
   if [ "${TARGETARCH}" = "arm64" ]; then \
@@ -30,7 +30,7 @@ RUN \
   && cat *aerospike-tools*.sha256 | cut -d' ' -f1) \
   && echo "$TOOLS_SHA256 *aerospike-tools.tgz" | sha256sum -c -
 
-FROM ubuntu:22.04 as install
+FROM debian:bookworm-slim as install
 
 # Work from /aerospike
 WORKDIR /aerospike


### PR DESCRIPTION
Reverts aerospike/aerospike-tools.docker#38

We want to use deb 12 slim until this is discussed more.