### PR TITLE
build and push to jfrog with metadata.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /build-metadata
+/meta-file

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/build-metadata

--- a/bake.hcl
+++ b/bake.hcl
@@ -9,6 +9,39 @@
 # Build all push images:
 #      docker buildx bake -f bake.hcl push --progressive plain --push
 
+
+#------------------------------------- jfrog -----------------------------------
+
+# For jfrog builds load first and then push with jf docker push
+
+
+group "push_jfrog" {
+	targets=["aerospike_tools_jfrog"]
+}
+
+target "aerospike_tools_jfrog" {
+	 tags=["artifact.aerospike.io/core-containers-dev-local/jfrog-test-aerospike-tools:11.0.2", "artifact.aerospike.io/core-containers-dev-local/jfrog-test-aerospike-tools:latest"]
+	 platforms=["linux/amd64", "linux/arm64"]
+	 context="."
+}
+
+group "test_jfrog" {
+	targets=["aerospike_tools_amd64_jfrog", "aerospike_tools_arm64_jfrog"]
+}
+
+target "aerospike_tools_amd64_jfrog" {
+	 tags=["artifact.aerospike.io/core-containers-dev-local/jfrog-test-aerospike-tools-amd64:11.0.2", "artifact.aerospike.io/core-containers-dev-local/jfrog-test-aerospike-tools-amd64:latest"]
+	 platforms=["linux/amd64"]
+	 context="."
+}
+
+target "aerospike_tools_arm64_jfrog" {
+	 tags=["artifact.aerospike.io/core-containers-dev-local/jfrog-test-aerospike-tools-arm64:11.0.2", "artifact.aerospike.io/core-containers-dev-local/jfrog-test-aerospike-tools-arm64:latest"]
+	 platforms=["linux/arm64"]
+	 context="."
+}
+
+
 #------------------------------------- test -----------------------------------
 
 group "test" {

--- a/build-with-buildinfo.sh
+++ b/build-with-buildinfo.sh
@@ -37,6 +37,5 @@ echo "$META_INFO" > meta-file
 jf rt build-docker-create --build-name "$BUILD_NAME" --build-number "$BUILD_NUMBER" core-containers-dev-local --image-file ./meta-file
 
 # Clean up
-rm -f meta-file
 
 echo "Docker build information created successfully."

--- a/build-with-buildinfo.sh
+++ b/build-with-buildinfo.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Enable strict mode for better error handling
+set -euo pipefail
+
+# Enable debug mode if DEBUG environment variable is set
+if [[ "${DEBUG:-}" == "true" ]]; then
+    set -x
+fi
+
+# Check if the correct number of arguments are provided
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 <build-name> <build-number>"
+    exit 1
+fi
+
+# Assign arguments to variables
+BUILD_NAME="$1"
+BUILD_NUMBER="$2"
+
+# Step 1: Build and push Docker images using Docker buildx bake
+docker buildx bake -f bake.hcl push_jfrog --no-cache --push --metadata-file=build-metadata
+
+# Step 2: Extract the first image name and SHA digest
+META_INFO=$(jq -r '.[] | {digest: .["containerimage.digest"], names: .["image.name"] | split(",")} | "\(.names[0])@\(.digest)"' build-metadata)
+
+# Check if the SHA digest and image name were found
+if [ -z "$META_INFO" ]; then
+    echo "Failed to extract SHA digest and image name from build-metadata."
+    exit 1
+fi
+
+# Prepare the meta file for jfrog
+echo "$META_INFO" > meta-file
+
+# Step 3: Use jf rt build-docker-create to create Docker build information
+jf rt build-docker-create --build-name "$BUILD_NAME" --build-number "$BUILD_NUMBER" core-containers-dev-local --image-file ./meta-file
+
+# Clean up
+rm -f meta-file
+
+echo "Docker build information created successfully."

--- a/build-with-buildinfo.sh
+++ b/build-with-buildinfo.sh
@@ -36,6 +36,8 @@ echo "$META_INFO" > meta-file
 # Step 3: Use jf rt build-docker-create to create Docker build information
 jf rt build-docker-create --build-name "$BUILD_NAME" --build-number "$BUILD_NUMBER" core-containers-dev-local --image-file ./meta-file
 
-# Clean up
+# Step 4: Publish the build information to JFrog Artifactory
+jf rt build-publish "$BUILD_NAME" "$BUILD_NUMBER"
 
-echo "Docker build information created successfully."
+
+echo "Docker build information created and published successfully."


### PR DESCRIPTION
This gives a working example of using buildx bake but still uploading build info and packages to jfrog.

in the bake file the `_jfrog` versions just tag to make jfrog ready. It is using core-containers-dev-local as its target (should it be ecosystem? I wasn't sure)

something like `docker buildx bake -f bake.hcl push_jfrog --no-cache --push --metadata-file=build-metadata` would do the build standalone but see the script `build-with-buildinfo.sh` 

This script bakes the image and pushes (but saves the metadata) Then it extracts the image meta into the format jfrog expects

`DEBUG=true ./build-with-buildinfo.sh jfrog-test-aerospike-tools howdy-phuc`

The last step should output where the build info lives

{
  "buildInfoUiUrl": "https://aerospike.jfrog.io/ui/builds/jfrog-test-aerospike-tools/howdy-phuc/1724902804205/published?buildRepo=artifactory-build-info"
}